### PR TITLE
Adds function to automatically apply W-VS bias dependent on secondary structure.

### DIFF
--- a/create_goVirt.py
+++ b/create_goVirt.py
@@ -222,8 +222,7 @@ def write_genfiles(file_pref, sym_pairs, missAt, indBB, missRes):
         for pair in sym_pairs:
             s2print = " %s  %s  \t ;  %s  %s \n" % (str(int(pair[0]) + missAt),
                                                     str(int(pair[1]) + missAt),
-                                                    str(int(
-                                                        pair[4] - missRes)),
+                                                    str(int(pair[4] - missRes)),
                                                     str(int(pair[5] - missRes)))
             # atom index and residue index adapted due to missing residues
             f.write(s2print)
@@ -334,7 +333,7 @@ def write_autobias(file_pref, indBB, missRes, idp_sig, itp, bias_alfa, bias_coil
         idp_end = missRes + len(indBB)
 
         ss = get_ss(itp)
-        
+
         eps = []
         for aa in ss:
             if aa == 'C':


### PR DESCRIPTION
Adds functionality to automatically apply W-VS bias dependent on secondary structure (see #5 and #3). Is applied by calling the `--auto_bias` flag.

The flags `--bias_alfa` `--bias_coil` and `--bias_beta` define the epsilon bias to be applied to each secondary structure element. Default values can also be added.

Secondary structure composition is retrieved from the martini itp file, which is supplied by the user using the `--itp` flag.

Additionally, several PEP8 and code clarity improvements were done.